### PR TITLE
Timeout options test

### DIFF
--- a/cmd/resgraph/viz/main.go
+++ b/cmd/resgraph/viz/main.go
@@ -154,13 +154,13 @@ func showStep(w http.ResponseWriter, cl cloud.Cloud, idx int, step *testlib.Step
 	outln("")
 
 	var viz exec.GraphvizTracer
-	ex, err := exec.NewSerialExecutor(result.Actions, exec.DryRunOption(false), exec.TracerOption(&viz))
+	ex, err := exec.NewSerialExecutor(cl, result.Actions, exec.DryRunOption(false), exec.TracerOption(&viz))
 	if err != nil {
 		outf("NewSerialExecutor() = %v, want nil", err)
 		return
 	}
 
-	execResult, err := ex.Run(context.Background(), cl)
+	execResult, err := ex.Run(context.Background())
 
 	outln("<h3>Plan</h3>")
 	outln("")

--- a/e2e/backend_service_update_test.go
+++ b/e2e/backend_service_update_test.go
@@ -162,12 +162,12 @@ func TestBackendServiceUpdate(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Fatalf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}

--- a/e2e/rgraph_update_action_test.go
+++ b/e2e/rgraph_update_action_test.go
@@ -132,12 +132,12 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -182,12 +182,12 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
+	ex, err = exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -231,12 +231,12 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
+	ex, err = exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -265,12 +265,12 @@ func TestHcUpdateType(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -309,12 +309,12 @@ func TestHcUpdateType(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
+	ex, err = exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -348,12 +348,12 @@ func TestUpdateBackendService(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -398,19 +398,19 @@ func TestUpdateBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
+	ex, err = exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
 	t.Logf("exec.NewSerialExecutor finished, res: %v", res)
 	if len(res.Pending) > 0 {
 		t.Logf("Executor has %v, pending actions %v", len(res.Pending), res.Pending)
-		res, err = ex.Run(ctx, theCloud)
+		res, err = ex.Run(ctx)
 		if err != nil || res == nil {
 			t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 		}

--- a/e2e/tcproute_test.go
+++ b/e2e/tcproute_test.go
@@ -421,11 +421,11 @@ func processGraphAndExpectActions(t *testing.T, graphBuilder *rgraph.Builder, ex
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud, result.Actions)
 	if err != nil {
 		t.Fatalf("exec.NewSerialExecutor err: %v", err)
 	}
-	res, err := ex.Run(context.Background(), theCloud)
+	res, err := ex.Run(context.Background())
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}

--- a/pkg/cloud/rgraph/exec/action_test.go
+++ b/pkg/cloud/rgraph/exec/action_test.go
@@ -29,9 +29,10 @@ import (
 // testAction is used for unit testing.
 type testAction struct {
 	ActionBase
-	name   string
-	events EventList
-	err    error
+	name    string
+	events  EventList
+	err     error
+	runHook func() error
 }
 
 func (a *testAction) String() string {
@@ -43,6 +44,11 @@ func (a *testAction) DryRun() EventList {
 }
 
 func (a *testAction) Run(context.Context, cloud.Cloud) (EventList, error) {
+	if a.runHook != nil {
+		if runErr := a.runHook(); runErr != nil {
+			a.err = runErr
+		}
+	}
 	return a.events, a.err
 }
 

--- a/pkg/cloud/rgraph/exec/executor.go
+++ b/pkg/cloud/rgraph/exec/executor.go
@@ -19,7 +19,6 @@ package exec
 import (
 	"context"
 	"fmt"
-
 	"time"
 )
 

--- a/pkg/cloud/rgraph/exec/executor.go
+++ b/pkg/cloud/rgraph/exec/executor.go
@@ -19,8 +19,6 @@ package exec
 import (
 	"context"
 	"fmt"
-
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 )
 
 type Result struct {
@@ -42,7 +40,7 @@ type ActionWithErr struct {
 type Executor interface {
 	// Run the actions. Returns non-nil if there was an error in execution of
 	// one or more Actions.
-	Run(context.Context, cloud.Cloud) (*Result, error)
+	Run(context.Context) (*Result, error)
 }
 
 type Option func(*ExecutorConfig)

--- a/pkg/cloud/rgraph/exec/executor.go
+++ b/pkg/cloud/rgraph/exec/executor.go
@@ -19,6 +19,8 @@ package exec
 import (
 	"context"
 	"fmt"
+
+	"time"
 )
 
 type Result struct {
@@ -55,6 +57,12 @@ func DryRunOption(dryRun bool) Option {
 	return func(c *ExecutorConfig) { c.DryRun = dryRun }
 }
 
+// TimeoutOption sets timeout for executor Run function.
+// This options can be used with parallel executor only.
+func TimeoutOption(t time.Duration) Option {
+	return func(c *ExecutorConfig) { c.Timeout = t }
+}
+
 // ErrorStrategy to use when an Action returns an error.
 type ErrorStrategy string
 
@@ -86,6 +94,7 @@ type ExecutorConfig struct {
 	Tracer        Tracer
 	DryRun        bool
 	ErrorStrategy ErrorStrategy
+	Timeout       time.Duration
 }
 
 func (c *ExecutorConfig) validate() error {

--- a/pkg/cloud/rgraph/exec/executor_parallel.go
+++ b/pkg/cloud/rgraph/exec/executor_parallel.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo"
+	"k8s.io/klog/v2"
+)
+
+var (
+	ErrPendingActions = errors.New("Executor did not process all actions")
+)
+
+func defaultParallelExecutorConfig() *ExecutorConfig {
+	return &ExecutorConfig{
+		DryRun:        false,
+		ErrorStrategy: ContinueOnError,
+		Timeout:       5 * time.Minute,
+	}
+}
+
+// NewParallelExecutor returns a new Executor that runs tasks multi-threaded.
+func NewParallelExecutor(c cloud.Cloud, pending []Action, opts ...Option) (*parallelExecutor, error) {
+	ret := &parallelExecutor{
+		config: defaultParallelExecutorConfig(),
+		cloud:  c,
+		result: &Result{Pending: pending},
+		pq:     algo.NewParallelQueue[Action](),
+	}
+	for _, opt := range opts {
+		opt(ret.config)
+	}
+
+	if err := ret.config.validate(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+type parallelExecutor struct {
+	config *ExecutorConfig
+	cloud  cloud.Cloud
+
+	// lock guards results
+	lock   sync.Mutex
+	result *Result
+
+	pq   *algo.ParallelQueue[Action]
+	done chan *TraceEntry
+}
+
+// parallelExecutor implements Executor.
+var _ Executor = (*parallelExecutor)(nil)
+
+// Run executes pending actions in parallel.
+func (ex *parallelExecutor) Run(ctx context.Context) (*Result, error) {
+	ex.queueRunnableActions()
+	subctx, cancel := context.WithTimeout(ctx, ex.config.Timeout)
+
+	queueErr := ex.pq.Run(subctx, ex.runAction)
+	cancel()
+	if queueErr != nil {
+		waitErr := ex.pq.WaitForOrphans(ctx)
+		if waitErr != nil {
+			return ex.result, fmt.Errorf("ParallelExecutor: WaitForOrphans: %w", waitErr)
+		}
+	}
+	if len(ex.result.Errors) > 0 || len(ex.result.Pending) != 0 {
+		return ex.result, ErrPendingActions
+	}
+	return ex.result, nil
+
+}
+
+func (ex *parallelExecutor) runAction(ctx context.Context, a Action) error {
+	te := &TraceEntry{
+		Action: a,
+		Start:  time.Now(),
+	}
+	klog.V(4).Infof("Run action %s", a)
+	events, runErr := a.Run(ctx, ex.cloud)
+	te.End = time.Now()
+	klog.V(4).Infof("Finish action %s, err: %v", a, runErr)
+
+	ex.addActionResult(a, runErr)
+
+	if runErr != nil {
+		klog.Infof("Got error  %v, from action %s error_strategy: %s", runErr, a, ex.config.ErrorStrategy)
+		// check error strategy and decide if new actions should be executed.
+		if ex.config.ErrorStrategy == StopOnError {
+			if ex.config.Tracer != nil {
+				ex.config.Tracer.Record(te, runErr)
+			}
+			return fmt.Errorf("parallelExecutor: StopOnError due to Action %s: %w", a, runErr)
+		}
+	} else {
+		// notify parents only when action finished with success
+		te.Signaled = ex.signal(events)
+	}
+
+	if ex.config.Tracer != nil {
+		ex.config.Tracer.Record(te, runErr)
+	}
+
+	// try to run pending tasks
+	ex.queueRunnableActions()
+	return nil
+}
+
+func (ex *parallelExecutor) queueRunnableActions() {
+	ex.lock.Lock()
+	defer ex.lock.Unlock()
+
+	klog.V(4).Infof("queueRunnableActions: %d actions pending", len(ex.result.Pending))
+
+	taskWasRun := false
+	var notRunnable []Action
+	for _, a := range ex.result.Pending {
+		if a.CanRun() {
+			klog.V(4).Infof("Run task: %s", a)
+			ex.pq.Add(a)
+			taskWasRun = true
+		} else {
+			notRunnable = append(notRunnable, a)
+		}
+	}
+	klog.V(4).Infof("queueRunnableActions: remaining %d pending actions", len(notRunnable))
+	// update Pending array only if actions were run
+	if taskWasRun {
+		ex.result.Pending = notRunnable
+	}
+}
+
+// signal notifies parents that action finished
+func (ex *parallelExecutor) signal(evs []Event) []TraceSignal {
+	ex.lock.Lock()
+	defer ex.lock.Unlock()
+	var ret []TraceSignal
+	for _, a := range ex.result.Pending {
+		for _, ev := range evs {
+			if a.Signal(ev) {
+				ret = append(ret, TraceSignal{Event: ev, SignaledAction: a})
+			}
+		}
+	}
+	return ret
+}
+
+func (ex *parallelExecutor) addActionResult(a Action, runErr error) {
+	ex.lock.Lock()
+	defer ex.lock.Unlock()
+	if runErr == nil {
+		ex.result.Completed = append(ex.result.Completed, a)
+	} else {
+		ex.result.Errors = append(ex.result.Errors, ActionWithErr{Action: a, Err: runErr})
+	}
+}

--- a/pkg/cloud/rgraph/exec/executor_parallel_test.go
+++ b/pkg/cloud/rgraph/exec/executor_parallel_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParallelExecutor(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		graph string
+		// pending should be sorted alphabetically for comparison.
+		pending []string
+		wantErr bool
+	}{
+		{
+			name:  "empty graph",
+			graph: "",
+		},
+		{
+			name:  "one action",
+			graph: "A",
+		},
+		{
+			name:  "action and dependency",
+			graph: "A -> B",
+		},
+		{
+			name:  "chain of 3 actions",
+			graph: "A -> B -> C",
+		},
+		{
+			name:  "two chains with common root",
+			graph: "A -> B -> C; A -> C",
+		},
+		{
+			name:    "two node cycle",
+			graph:   "A -> B -> A",
+			pending: []string{"A", "B"},
+			wantErr: true,
+		},
+		{
+			name:  "lot of children",
+			graph: "A -> B; A -> C; A -> D -> B; A -> E -> F; A -> G",
+		},
+		{
+			name:  "complex fan in",
+			graph: "A -> Z; B -> Z; C -> D -> B",
+		},
+		{
+			name:    "cycle in larger graph",
+			graph:   "A -> B -> C -> D -> C; X -> Y",
+			pending: []string{"C", "D"},
+			wantErr: true,
+		},
+		{
+			name:    "error in action",
+			graph:   "A -> B -> !C -> D",
+			pending: []string{"D"},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCloud := cloud.NewMockGCE(&cloud.SingleProjectRouter{ID: "proj1"})
+			actions := actionsFromGraphStr(tc.graph)
+
+			ex, err := NewParallelExecutor(mockCloud,
+				actions,
+				TimeoutOption(1*time.Minute),
+				ErrorStrategyOption(StopOnError))
+			if err != nil {
+				t.Fatalf("NewParallelExecutor(_, _) = %v, want nil", err)
+			}
+			result, err := ex.Run(context.Background())
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("ex.Run(_, _) = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
+			}
+			got := sortedStrings(result.Pending, func(a Action) string { return a.(*testAction).name })
+			if diff := cmp.Diff(got, tc.pending); diff != "" {
+				t.Errorf("pending: diff -got,+want: %s", diff)
+			}
+		})
+	}
+}
+
+func TestParallelExecutorErrorStrategy(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		graph string
+		// pending should be sorted alphabetically for comparison.
+		pending []string
+		errs    []string
+	}{
+		{
+			name:    "linear graph",
+			graph:   "A -> !B -> C -> D -> E",
+			pending: []string{"C", "D", "E"},
+			errs:    []string{"B"},
+		},
+		{
+			name:    "branched graph",
+			graph:   "A -> !B -> C; A -> D; A -> E; A -> F",
+			pending: []string{"C"},
+			errs:    []string{"B"},
+		},
+	} {
+		mockCloud := cloud.NewMockGCE(&cloud.SingleProjectRouter{ID: "proj1"})
+		actions := actionsFromGraphStr(tc.graph)
+
+		for _, strategy := range []ErrorStrategy{StopOnError, ContinueOnError} {
+			name := tc.name + " " + string(strategy)
+			t.Run(name, func(t *testing.T) {
+				ex, err := NewParallelExecutor(mockCloud,
+					actions,
+					ErrorStrategyOption(strategy),
+					TimeoutOption(10*time.Second))
+				if err != nil {
+					t.Fatalf("NewParallelExecutor() = %v, want nil", err)
+				}
+				result, err := ex.Run(context.Background())
+				if err == nil {
+					t.Fatalf("Run() = %v; expected error", err)
+				}
+				gotErrs := sortedStrings(result.Errors, func(a ActionWithErr) string { return a.Action.(*testAction).name })
+
+				if diff := cmp.Diff(gotErrs, tc.errs); diff != "" {
+					t.Errorf("errors: diff -got,+want: %s", diff)
+				}
+				got := sortedStrings(result.Pending, func(a Action) string { return a.(*testAction).name })
+				if diff := cmp.Diff(got, tc.pending); diff != "" {
+					t.Errorf("pending: diff -got,+want: %s", diff)
+				}
+			})
+		}
+	}
+}

--- a/pkg/cloud/rgraph/exec/executor_serial_test.go
+++ b/pkg/cloud/rgraph/exec/executor_serial_test.go
@@ -96,14 +96,15 @@ func TestSerialExecutor(t *testing.T) {
 					actions := actionsFromGraphStr(tc.graph)
 
 					tr := NewGraphvizTracer()
-					ex, err := NewSerialExecutor(actions,
+					ex, err := NewSerialExecutor(nil,
+						actions,
 						ErrorStrategyOption(StopOnError),
 						TracerOption(tr),
 						DryRunOption(dryRun == "dry run"))
 					if err != nil {
 						t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 					}
-					result, err := ex.Run(context.Background(), nil)
+					result, err := ex.Run(context.Background())
 					if gotErr := err != nil; gotErr != tc.wantErr {
 						t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
 					}
@@ -160,14 +161,15 @@ func TestSerialExecutorErrorStrategy(t *testing.T) {
 			actions := actionsFromGraphStr(tc.graph)
 
 			var tr GraphvizTracer
-			ex, err := NewSerialExecutor(actions,
+			ex, err := NewSerialExecutor(nil,
+				actions,
 				ErrorStrategyOption(tc.strategy),
 				TracerOption(&tr),
 				DryRunOption(false))
 			if err != nil {
 				t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 			}
-			result, err := ex.Run(context.Background(), nil)
+			result, err := ex.Run(context.Background())
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
 			}

--- a/pkg/cloud/rgraph/workflow/plan/plan_test.go
+++ b/pkg/cloud/rgraph/workflow/plan/plan_test.go
@@ -133,11 +133,11 @@ func TestLB(t *testing.T) {
 	}
 
 	var viz exec.GraphvizTracer
-	ex, err := exec.NewSerialExecutor(res.Actions, exec.DryRunOption(true), exec.TracerOption(&viz))
+	ex, err := exec.NewSerialExecutor(nil, res.Actions, exec.DryRunOption(true), exec.TracerOption(&viz))
 	if err != nil {
 		t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 	}
-	execResult, err := ex.Run(context.TODO(), nil)
+	execResult, err := ex.Run(context.TODO())
 	for _, p := range execResult.Pending {
 		t.Logf("%+v", p.Metadata())
 	}


### PR DESCRIPTION
This PR is a POC for complex test for parallel-executor testing agains TimeoutOptions and  passing context with timeout to executor.

In this PR we have 2 tests with the same scenarios.
1. Create 3 actions A -> !B; A-> C
2. Action C is a long running action which execution time is greater than timeout 
3. Create and executor with 5sec timeout
 
In first test we use Run function which uses TimeoutOptions to cancel subcontext on timeout.
In second tests we are passing contextWithTimeout to RunWithoutConfigTimeout function

As a result we can see that in second test we are not waiting for all actions to finish after timeout and we are missing the information that some actions are still running. 

Detailed test results: https://screenshot.googleplex.com/ALNfeEBv8Bd3ZuF
